### PR TITLE
Register with service registry on deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: ci
+name: cd
 
 on:
   push:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -138,4 +138,4 @@ jobs:
           service_namespace: octue
           service_name: ${{ needs.info.outputs.gcp_resource_affix }}-${{ needs.info.outputs.gcp_service_name }}
           service_revision_tag: ${{ needs.info.outputs.version }}
-          service_registry_endpoint: https://exa-main-server-fhngvhbkyq-ew.a.run.app/example-app-urls/services
+          service_registry_endpoint: https://exa-main-server-fhngvhbkyq-ew.a.run.app/example-app-urls/integrations/octue/services

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,20 +139,3 @@ jobs:
           service_name: ${{ needs.info.outputs.gcp_resource_affix }}-${{ needs.info.outputs.gcp_service_name }}
           service_revision_tag: ${{ needs.info.outputs.version }}
           service_registry_endpoint: https://exa-main-server-fhngvhbkyq-ew.a.run.app/example-app-urls/services
-
-  release:
-    # This job will only run if the PR has been merged (and not closed without merging).
-    if: "github.event.pull_request.merged == true"
-    runs-on: ubuntu-latest
-    needs: [info, build]
-    steps:
-      - name: Create release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, no need to create your own.
-        with:
-          tag_name: ${{ needs.info.outputs.version }}
-          release_name: ${{ github.event.pull_request.title }}
-          body: ${{ github.event.pull_request.body }}
-          draft: false
-          prerelease: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,20 @@ jobs:
           service_name: ${{ needs.info.outputs.gcp_resource_affix }}-${{ needs.info.outputs.gcp_service_name }}
           service_revision_tag: ${{ needs.info.outputs.version }}
           service_registry_endpoint: https://exa-main-server-fhngvhbkyq-ew.a.run.app/example-app-urls/services
+
+  release:
+    # This job will only run if the PR has been merged (and not closed without merging).
+    if: "github.event.pull_request.merged == true"
+    runs-on: ubuntu-latest
+    needs: [info, build]
+    steps:
+      - name: Create release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, no need to create your own.
+        with:
+          tag_name: ${{ needs.info.outputs.version }}
+          release_name: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,11 @@ jobs:
           service_name: ${{ needs.info.outputs.gcp_resource_affix }}-${{ needs.info.outputs.gcp_service_name }}
           service_revision_tag: ${{ needs.info.outputs.version }}
           push_endpoint: ${{ steps.deploy_service.outputs.url }}
+
+      - name: Register service revision
+        uses: octue/register-service-revision@0.2.0
+        with:
+          service_namespace: octue
+          service_name: ${{ needs.info.outputs.gcp_resource_affix }}-${{ needs.info.outputs.gcp_service_name }}
+          service_revision_tag: ${{ needs.info.outputs.version }}
+          service_registry_endpoint: https://exa-main-server-fhngvhbkyq-ew.a.run.app/example-app-urls/services

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,13 @@
-# This workflow tests and releases a new version of the package, then publishes it to PyPi and the
-# octue/octue-sdk-python Docker Hub repository.
+# This workflow tests a new version of the service.
 
 name: ci
 
 # Only trigger when a pull request into main branch is merged.
 on:
   pull_request:
-    branches-ignore:
-      - main
 
 jobs:
   run-tests:
-    if: "github.event.pull_request.merged == true"
     runs-on: ubuntu-latest
     env:
       USING_COVERAGE: "3.9"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   run-tests:
+    if: "!contains(github.event.head_commit.message, 'skipci')"
     runs-on: ubuntu-latest
     env:
       USING_COVERAGE: "3.9"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
-# This workflow tests a new version of the service.
-
 name: ci
 
-# Only trigger when a pull request into main branch is merged.
 on:
-  pull_request:
+  push:
+    branches-ignore:
+      - main
 
 jobs:
   run-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+# This workflow tests and releases a new version of the package, then publishes it to PyPi and the
+# octue/octue-sdk-python Docker Hub repository.
+
+name: ci
+
+# Only trigger when a pull request into main branch is merged.
+on:
+  pull_request:
+    branches-ignore:
+      - main
+
+jobs:
+  run-tests:
+    if: "github.event.pull_request.merged == true"
+    runs-on: ubuntu-latest
+    env:
+      USING_COVERAGE: "3.9"
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.3.2
+
+      - name: Check pyproject.toml file
+        run: poetry check
+
+      - name: Install package
+        run: poetry install
+
+      - name: Authenticate with Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.6.0
+        with:
+          # NOTE: If setting create_credentials_file=true, .dockerignore file must include `gha-creds-*.json` to avoid baking these credentials into build
+          create_credentials_file: true
+          workload_identity_provider: "projects/437801218871/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider"
+          service_account: "github-actions@octue-sdk-python.iam.gserviceaccount.com"
+
+      - name: Run tests
+        env:
+          TEST_PROJECT_NAME: ${{ secrets.TEST_PROJECT_NAME }}
+          GOOGLE_CLOUD_PROJECT: ${{ secrets.TEST_PROJECT_NAME }}
+        run: poetry run python -m unittest
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+# This workflow tests and releases a new version of the package, then publishes it to PyPi and the
+# octue/octue-sdk-python Docker Hub repository.
+
+name: Release
+
+# Only trigger when a pull request into main branch is merged.
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  run-tests:
+    if: "github.event.pull_request.merged == true"
+    runs-on: ${{ matrix.os }}
+    env:
+      USING_COVERAGE: "3.9"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.3.2
+
+      - name: Check pyproject.toml file
+        run: poetry check
+
+      - name: Get package version
+        id: get-package-version
+        run: echo "PACKAGE_VERSION=$(poetry version -s)" >> $GITHUB_OUTPUT
+
+      - name: Install package
+        run: poetry install
+
+      - name: Authenticate with Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0.6.0
+        with:
+          # NOTE: If setting create_credentials_file=true, .dockerignore file must include `gha-creds-*.json` to avoid baking these credentials into build
+          create_credentials_file: true
+          workload_identity_provider: "projects/437801218871/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider"
+          service_account: "github-actions@octue-sdk-python.iam.gserviceaccount.com"
+
+      - name: Run tests
+        env:
+          TEST_PROJECT_NAME: ${{ secrets.TEST_PROJECT_NAME }}
+          GOOGLE_CLOUD_PROJECT: ${{ secrets.TEST_PROJECT_NAME }}
+        run: poetry run python -m unittest
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
+
+    outputs:
+      package_version: ${{ steps.get-package-version.outputs.PACKAGE_VERSION }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: run-tests
+    steps:
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, no need to create your own.
+        with:
+          tag_name: ${{ needs.run-tests.outputs.package_version }}
+          release_name: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,9 @@ on:
 jobs:
   run-tests:
     if: "github.event.pull_request.merged == true"
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     env:
       USING_COVERAGE: "3.9"
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
     permissions:
       id-token: write
     steps:

--- a/octue.yaml
+++ b/octue.yaml
@@ -3,8 +3,3 @@ services:
     namespace: octue
     app_source_path: exa_foo_fighting_service
     app_configuration_path: app_configuration.json
-    project_name: octue-amy
-    region: europe-west2
-    repository_owner: octue
-    repository_name: exa-foo-fighting-service
-    memory: 1Gi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "exa-foo-fighting-service"
-version = "0.2.0"
+version = "0.2.1"
 description = ""
 authors = ["Marcus Lugg <cortado.codes@protonmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#4](https://github.com/octue/exa-foo-fighting-service/pull/4))

### Operations
- Register service revision on deploy
- Add release workflow
- Rename `ci` workflow to `cd`
- Add `ci` workflow for testing

### Chores
- Remove unused config from `octue.yaml`

<!--- END AUTOGENERATED NOTES --->